### PR TITLE
Resolve #1:`NPM WARN` flags for `react-server-dom-webpack`

### DIFF
--- a/.codesandbox/Dockerfile
+++ b/.codesandbox/Dockerfile
@@ -1,1 +1,2 @@
 FROM node:20.5.1
+RUN npm install -g gatsby ncu

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 .cache/
 public
-.nvmrc

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "react-dom": "^18.2.0",
     "@babel/eslint-parser": "^7.22.11"
   },
+  "overrides": {
+    "react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825": {
+      "react": "^18.2.0"
+    }
+  },
   "main": "index.js",
   "repository": "https://github.com/takagiyuuki/portfolio.git",
   "license": "MIT"


### PR DESCRIPTION
## I found the answer on the following sites

https://stackoverflow.com/questions/74453995/clean-gatsby-5-2-install-throwing-npm-warn-flags-for-react-server-dom-webpack

https://github.com/gatsbyjs/gatsby/issues/37242#issuecomment-1396620944